### PR TITLE
Speed Improvements and _Json_GeneratePretty

### DIFF
--- a/JSON.au3
+++ b/JSON.au3
@@ -370,6 +370,7 @@ EndFunc   ;==>_JSON_Generate
 ;                              = 4 - index query on none array object
 ;                              = 5 - index out of array range
 ; Author ........: AspirinJunkie
+; Modified ......: OfficialLambdax (Converting the VarGetType() string into a int, for a slight speed boost)
 ; =================================================================================================
 Func _JSON_Get(ByRef $o_Object, Const $s_Pattern)
 	Local $o_Current = $o_Object, $d_Val
@@ -380,13 +381,13 @@ Func _JSON_Get(ByRef $o_Object, Const $s_Pattern)
 
 		If UBound($a_CurToken) = 3 Then ; KeyName
 			$a_CurToken[2] = StringRegExpReplace($a_CurToken[2], '\\(.)', '$1')
-			Switch VarGetType($o_Current)
-				Case "Object"
+			Switch $_JSON_TYPES[VarGetType($o_Current)]
+				Case 6 ; Object
 					If Not IsObj($o_Current) Or ObjName($o_Current) <> "Dictionary" Then Return SetError(2, 0, "")
 					If Not $o_Current.Exists($a_CurToken[2]) Then Return SetError(3, 0, "")
 
 					$o_Current = $o_Current($a_CurToken[2])
-				Case "Map"
+				Case 7 ; Map
 					If Not MapExists($o_Current, $a_CurToken[2]) Then Return SetError(3, 0, "")
 
 					$o_Current = $o_Current[$a_CurToken[2]]
@@ -762,7 +763,7 @@ Func __JSON_Types()
 	Local $arTypes = StringSplit($sTypes, ',', 1), $arType[2]
 
 	For $i = 1 To $arTypes[0]
-		$arType = StringSplit($arTypes[$i], ':', 2)
+		$arType = StringSplit($arTypes[$i], ':', 3)
 		$mTypes[$arType[0]] = $arType[1]
 	Next
 


### PR DESCRIPTION
1) I copied and renamed _Json_Generate to _Json_GeneratePretty, because it produces pretty Json at default.

2) The copy, _Json_Generate, i then modified to no longer produce any Pretty json. So all the `, $s_ObjIndent = @TAB, $s_ObjDelEl = @CRLF, $s_ObjDelKey = "", $s_ObjDelVal = " ", $s_ArrIndent = @TAB, $s_ArrDelEl = @CRLF` got removed.

I personally only need pretty json in certain circumstances. And not producing pretty json increases the Performance by alot. The required generation time is nearly halfed by this.

3) Then i Created a global constant map, that can resolve var types to integers. This is used in _Json_Generate, _Json_GeneratePretty and _Json_Get. The String returned from VarGetType is converted into a Int and this Int is then Switched. This improvement is tiny.

In a 6kb test Json, the one below. This improves the time by 200 ms (1000 Iterations).
This improvement could also be made to _JSON_addChangeDelete, but i didnt.

I also didnt touch the Dictionary.au3

[random.zip](https://github.com/Sylvan86/autoit-json-udf/files/11487346/random.zip)
